### PR TITLE
Add Github metadata folder

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+## Contributing to Relief Supports
+
+TODO

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Issue Description
+
+## Environment Issue Experienced In
+www.reliefsupports.org
+
+## Additional Information
+Browser:
+OS:
+
+[] This issue is not already reported.


### PR DESCRIPTION
# What you've done
In this PR I've added the `.github` metadata folder to include templates and guidelines that Github automatically picks up. Furthermore, I've added a simple `ISSUE_TEMPLATE.md` and an empty `CONTRIBUTING.md` that will have to be filled out later when the processes get clearer.

# Why have you done it
To organize contributions from the distributed team of devs.

# Screenshot (if visual)
N/A

# Any testing carried out
N/A